### PR TITLE
feat: add nodejsParameters setting to enable custom node settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nodejs-testing
 
-Provide integration with VS Code using the [`node:test` runner](https://nodejs.org/api/test.html). Simply install the extension and start running tests, no setup required.[*](#having-problems-read-this)
+Provide integration with VS Code using the [`node:test` runner](https://nodejs.org/api/test.html). Simply install the extension and start running tests, no setup required.[\*](#having-problems-read-this)
 
 **This extension requires Node.js >=19**: `node:test` is quite new and did not offer features we need in prior versions.
 
@@ -13,11 +13,17 @@ Provide integration with VS Code using the [`node:test` runner](https://nodejs.o
 - If tests aren't initially found in your workspace folder, this extension won't keep watching for changes. Manually run the "refresh tests" action if you later add some (or just reload your window.)
 
 ![](./screenshot.png)
-*Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong)*
+_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong)_
 
 ## Configuring
 
 - `nodejs-testing.include` is the list of directories in which to look for test files, relative to your workspace folder. Defaults to `['./']`.
-- `nodejs-testing.exclude` is the list of glob patterns that should be excluded from the search.  Defaults to `['**/node_modules/**']`.
+- `nodejs-testing.exclude` is the list of glob patterns that should be excluded from the search. Defaults to `['**/node_modules/**']`.
 - `nodejs-testing.concurrency` is how many test files to run in parallel. Setting it to 0 (default) will use the number of CPU cores - 1.
 - `nodejs-testing.nodejsPath` is the path to the Node.js binary to use for running tests. If unset, will try to find Node on your PATH.
+- `nodejs-testing.nodejsParameters` Additional Parameters that will be passed onto the node process. Each parameter is a separate item in the array.
+
+  To get for example `node --import /abs/path/to/file.js` you need 2 entries
+
+  1.  `--import`
+  2.  `${workspaceFolder}/to/file.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nodejs-testing",
       "version": "1.0.3",
       "dependencies": {
+        "@c4312/vscode-variables": "^1.0.0",
         "@hediet/json-rpc": "^0.3.0",
         "@hediet/json-rpc-streams": "https://gitpkg.now.sh/hediet/typed-json-rpc/json-rpc-streams?d4d660cf19acd424ef4f782822efc34c01f97c1a",
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -41,6 +42,11 @@
       "engines": {
         "vscode": "^1.74.0"
       }
+    },
+    "node_modules/@c4312/vscode-variables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@c4312/vscode-variables/-/vscode-variables-1.0.0.tgz",
+      "integrity": "sha512-Huk2Eg5D8f8ALlll8e4wViPCWta+4W61I7azdi0Bg6f327EHr9lI3UW80vlSreD+pfxTm/oOe/MB8crQhQOB8A=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.5",
@@ -3102,6 +3108,11 @@
     }
   },
   "dependencies": {
+    "@c4312/vscode-variables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@c4312/vscode-variables/-/vscode-variables-1.0.0.tgz",
+      "integrity": "sha512-Huk2Eg5D8f8ALlll8e4wViPCWta+4W61I7azdi0Bg6f327EHr9lI3UW80vlSreD+pfxTm/oOe/MB8crQhQOB8A=="
+    },
     "@esbuild/android-arm": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.5.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
             "default": "node",
             "description": "Path to the Node.js binary used to run tests"
           },
+          "nodejs-testing.nodejsParameters": {
+            "type": "array",
+            "markdownDescription": "Additional Parameters that will be passed onto the node process. Each parameter is a separate item in the array. \n\n To get for example `node --import /abs/path/to/file.js` you need 2 entries \n 1. `--import` \n 2. `${workspaceFolder}/to/file.js`.",
+            "default": [],
+            "items": {
+              "type": "string"
+            }
+          },
           "nodejs-testing.include": {
             "type": "array",
             "markdownDescription": "Directories which to find tests, relative to your workspace folder. Files that match the [Node.js test patterns](https://nodejs.org/api/test.html#test-runner-execution-model) will be included.\n\nNote: if you compile your code, this should point to the location of your compiled files, not your source files.",
@@ -102,6 +110,7 @@
     "printWidth": 100
   },
   "dependencies": {
+    "@c4312/vscode-variables": "^1.0.0",
     "@hediet/json-rpc": "^0.3.0",
     "@hediet/json-rpc-streams": "https://gitpkg.now.sh/hediet/typed-json-rpc/json-rpc-streams?d4d660cf19acd424ef4f782822efc34c01f97c1a",
     "@jridgewell/trace-mapping": "^0.3.17",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,8 @@ export async function activate(context: vscode.ExtensionContext) {
     smStore,
     new ConfigValue("concurrency", 0),
     new ConfigValue("nodejsPath", "node"),
-    context.extensionUri.fsPath
+    context.extensionUri.fsPath,
+    new ConfigValue("nodejsParameters", [])
   );
 
   const ctrls = new Map<vscode.WorkspaceFolder, Controller>();


### PR DESCRIPTION
## What I did

1. add a setting `nodejsParameters`
2. resolve vscode globals in those parameters so you can use things like `${workspaceFolder}` - ideally this would be done by vscode itself but it's an [open issue ](https://github.com/microsoft/vscode/issues/46471)
3. pass those parameter onto the node spawn

solves
- #4
- #8 
- #10 