### PR TITLE
add envFile support for test runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "acorn-loose": "^8.4.0",
         "ansi-colors": "^4.1.3",
         "data-uri-to-buffer": "^6.0.2",
+        "dotenv": "^16.4.5",
         "estraverse": "^5.3.0",
         "picomatch": "^4.0.1",
         "pretty-format": "^29.7.0",
@@ -1523,6 +1524,17 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {
@@ -5250,6 +5262,11 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true
+    },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
     },
     "eastasianwidth": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -128,8 +128,16 @@
           },
           "nodejs-testing.envFile": {
             "type": "string",
-            "description": "Absolute path to a file containing environment variable definitions.\n\nNote: template parameters like ${workspaceFolder} will be resolved.",
+            "markdownDescription": "Absolute path to a file containing environment variable definitions.\n\nNote: template parameters like ${workspaceFolder} will be resolved.",
             "default": ""
+          },
+          "nodejs-testing.env": {
+            "type": "object",
+            "markdownDescription": "Environment variables passed to the program. The value null removes the variable from the environment.\n\nNote: This takes precedence over envFile.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {}
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -125,6 +125,11 @@
                 }
               }
             }
+          },
+          "nodejs-testing.envFile": {
+            "type": "string",
+            "description": "Absolute path to a file containing environment variable definitions.\n\nNote: template parameters like ${workspaceFolder} will be resolved.",
+            "default": ""
           }
         }
       }
@@ -184,6 +189,7 @@
     "acorn-loose": "^8.4.0",
     "ansi-colors": "^4.1.3",
     "data-uri-to-buffer": "^6.0.2",
+    "dotenv": "^16.4.5",
     "estraverse": "^5.3.0",
     "picomatch": "^4.0.1",
     "pretty-format": "^29.7.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.extensionUri.fsPath,
     new ConfigValue("nodejsParameters", []),
     new ConfigValue("envFile", ""),
+    new ConfigValue("env", {}),
     extensions,
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ export async function activate(context: vscode.ExtensionContext) {
     new ConfigValue("style", Style.Spec),
     context.extensionUri.fsPath,
     new ConfigValue("nodejsParameters", []),
+    new ConfigValue("envFile", ""),
     extensions,
   );
 

--- a/src/runner-protocol.ts
+++ b/src/runner-protocol.ts
@@ -92,6 +92,7 @@ export const contract = makeContract({
             parameters: s.sArrayOf(s.sString()),
           }),
         ),
+        extraEnv: s.sMap(s.sString()),
       }),
       result: s.sObject({
         status: s.sNumber(),

--- a/src/runner-worker.ts
+++ b/src/runner-worker.ts
@@ -42,6 +42,7 @@ const start: (typeof contract)["TClientHandler"]["start"] = async ({
   files,
   extensions,
   verbose,
+  extraEnv,
 }) => {
   const majorVersion = /^v([0-9]+)/.exec(process.version);
   if (!majorVersion || Number(majorVersion[1]) < 19) {
@@ -51,7 +52,7 @@ const start: (typeof contract)["TClientHandler"]["start"] = async ({
   const todo: Promise<void>[] = [];
   for (let i = 0; i < concurrency && i < files.length; i++) {
     const prefix = colors[i % colors.length](`worker${i + 1}> `);
-    todo.push(doWork(prefix, files, extensions, verbose));
+    todo.push(doWork(prefix, files, extensions, verbose, extraEnv));
   }
   await Promise.all(todo);
 
@@ -63,6 +64,7 @@ async function doWork(
   queue: ITestRunFile[],
   extensions: ExtensionConfig[],
   verbose: boolean,
+  extraEnv: Record<string, string>,
 ) {
   while (queue.length) {
     const next = queue.pop()!;
@@ -96,6 +98,7 @@ async function doWork(
           // enable color for modules that use `supports-color` or similar
           FORCE_COLOR: "true",
           ...process.env,
+          ...extraEnv,
         },
       });
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -38,6 +38,7 @@ export class TestRunner {
     extensionDir: string,
     private readonly nodejsParameters: ConfigValue<string[]>,
     private readonly envFile: ConfigValue<string>,
+    private readonly env: ConfigValue<Record<string, string>>,
     private readonly extensions: ConfigValue<ExtensionConfig[]>,
   ) {
     this.workerPath = join(extensionDir, "out", "runner-worker.js");
@@ -88,9 +89,14 @@ export class TestRunner {
         const outputQueue = new OutputQueue();
 
         const extensions = this.extensions.value;
-        const extraEnv = this.envFile.value
-          ? parseEnv(await fs.readFile(replaceVariables(this.envFile.value), "utf-8"))
-          : {};
+        const envFile = this.envFile.value
+          ? await fs.readFile(replaceVariables(this.envFile.value))
+          : null;
+        const envFileValues = envFile ? parseEnv(envFile) : {};
+        const extraEnv = {
+          ...envFileValues,
+          ...this.env.value,
+        };
 
         await new Promise<void>((resolve, reject) => {
           const socket = getRandomPipe();


### PR DESCRIPTION
Unfortunately using "--env-file" does not seem to be work with worker threads. Therefore to enable passing a test env to your tests, the new `envFile` and `env` settings can be set in the workspace settings. This is then in line with vscode launch configurations.