### PR TITLE
Discussion: allow extension to function when `node:test` is wrapped by a convenience function

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -5,12 +5,12 @@ import picomatch from "picomatch";
 import * as vscode from "vscode";
 import { coverageContext } from "./coverage";
 import { DisposableStore, MutableDisposable } from "./disposable";
+import { ExtensionConfig } from "./extension-config";
 import { last } from "./iterable";
 import { ICreateOpts, ItemType, getContainingItemsForFile, testMetadata } from "./metadata";
 import { IParsedNode, parseSource } from "./parsing";
 import { RunHandler, TestRunner } from "./runner";
 import { ISourceMapMaintainer, SourceMapStore } from "./source-map-store";
-import { ExtensionConfig } from './extension-config';
 
 const diagnosticCollection = vscode.languages.createDiagnosticCollection("nodejs-testing-dupes");
 
@@ -174,7 +174,8 @@ export class Controller {
       return;
     }
 
-    const tree = parseSource(contents);
+    console.log(uri.fsPath);
+    const tree = parseSource(contents, uri.fsPath);
     if (!tree.length) {
       this.deleteFileTests(uri.toString());
       return;


### PR DESCRIPTION
**Context**
My company has a 10 year old node.js codebase, and we have recently converted it to use `node:test`.  However, in order to successfully migrate, and for future-proofing the testing - we have wrapped the `test` function up in our own function.


```Typescript
// test/utils.ts
import { test as nodeTest } from 'node:test';

export class TestContext = // a class with a bunch of test helpers on it

type TestFn = (t: TestContext) => Promise<any>;

export function test(name: string, testFn: TestFn) {
  return nodeTest(name, async (t) => {
    const context = new TestContext(t);
    return testFn(context);
  });
}
```

We have started to work on making the codebase accessible to very junior developers, and wanted to have "click to run tests" functionality, and stumbled upon this extension.  It is honestly great, but changing all of our tests to use `node:test` directly is a bit too much to ask.

**Request up for discussion**
I'd like to add a setting / configuration that allows for specifying a "test function override" - where you can specify where your test wrapper function is (instead of `import { test } from 'node:test';` it might be `import { test } from './utils';` for example ).

This would allow us to use this extension for our testing with minimal changes to the codebase, and provide a single place to update if we ever switched to vitest (for example) or jest or whatever new testing framework comes around in 10 more years.

**Other examples**
We hit a similar problem with typescript-eslint and I thought their solution to it was elegant, where they allow specifying a callable function with a [TypeOrValueSpecifier](https://typescript-eslint.io/packages/type-utils/type-or-value-specifier) .
```
      "@typescript-eslint/no-floating-promises": [
        "error",
        {
          // The recommended usage of top level tests in node:test is to leave those promises floating
          allowForKnownSafeCalls: [
            {
              from: "package",
              name: ["test", "it", "describe", "suite"],
              package: "node:test",
            },
            {
              from: "file",
              name: "test",
              path: "test/utils.ts",
            },
          ],
        },
      ],
```

**Proposal**
I think nodejs-testing could adopt a setting that accepted a TypeOrValueSpecifier.  The default value of this setting would be:

```Javascript
{
  from: "package", 
  name: ["test", "it"],
  package: "node:test",
}
```

But anyone who wanted to wrap the test function would replace it with the `TypeOfValueSpecifier` that matched their wrapped test function.

```Javascript
{
  from: "file", 
  name: ["test"],
  path: "test/utils.ts",
}
```

_The code I attached to this was a very very hacky proof of concept I did to ensure it would work in theory, it is by no means a suggestion to merge this code.  I just wanted to have a discussion before doing the "real" implementaiton_.