### PR TITLE
runner: add --test-force-exit and --test-isolation options

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,19 @@
             "default": "node",
             "description": "Path to the Node.js binary used to run tests"
           },
+          "nodejs-testing.isolation": {
+            "description": "Add the --test-isolation=? flag if supported",
+            "default": "process",
+            "enum": [
+              "process",
+              "none"
+            ]
+          },
+          "nodejs-testing.forceExit": {
+            "type": "boolean",
+            "default": false,
+            "description": "Add the --test-force-exit flag if supported"
+          },
           "nodejs-testing.nodejsParameters": {
             "type": "array",
             "deprecationMessage": "Use nodejs-testing.extensions instead!",

--- a/src/node-version.ts
+++ b/src/node-version.ts
@@ -1,5 +1,7 @@
 export const enum Capability {
   ExperimentalSnapshots = 1 << 0,
+  TestForceExit = 1 << 1,
+  TestIsolation = 1 << 2,
 }
 
 export class NodeVersion {
@@ -15,6 +17,19 @@ export class NodeVersion {
     // to stable 24 then then should be updated to lt(new Semver(25, 0, 0))
     if (semver.gte(new Semver(22, 3, 0)) && semver.lt(new Semver(24, 0, 0))) {
       this.capabilities |= Capability.ExperimentalSnapshots;
+    }
+
+    // --test-force-exit was added in v22.0.0, and backported in v20.10.0
+    if (
+      semver.gte(new Semver(22, 0, 0)) ||
+      (semver.major === 20 && semver.gte(new Semver(20, 10, 0)))
+    ) {
+      this.capabilities |= Capability.TestForceExit;
+    }
+
+    // --test-isolation was added in v22.0.0, and backported in v20.10.0
+    if (semver.gte(new Semver(22, 8, 0))) {
+      this.capabilities |= Capability.TestIsolation;
     }
   }
 

--- a/src/node-version.ts
+++ b/src/node-version.ts
@@ -1,7 +1,8 @@
 export const enum Capability {
   ExperimentalSnapshots = 1 << 0,
   TestForceExit = 1 << 1,
-  TestIsolation = 1 << 2,
+  ExperimentalTestIsolation = 1 << 2,
+  TestIsolation = 1 << 3,
 }
 
 export class NodeVersion {
@@ -19,16 +20,21 @@ export class NodeVersion {
       this.capabilities |= Capability.ExperimentalSnapshots;
     }
 
-    // --test-force-exit was added in v22.0.0, and backported in v20.10.0
+    // --test-force-exit was added in v22.0.0, and backported in v20.14.0
     if (
       semver.gte(new Semver(22, 0, 0)) ||
-      (semver.major === 20 && semver.gte(new Semver(20, 10, 0)))
+      (semver.major === 20 && semver.gte(new Semver(20, 14, 0)))
     ) {
       this.capabilities |= Capability.TestForceExit;
     }
 
-    // --test-isolation was added in v22.0.0, and backported in v20.10.0
-    if (semver.gte(new Semver(22, 8, 0))) {
+    // --experimental-test-isolation was added in v22.8.0, and removed in v23.6.0
+    if (semver.gte(new Semver(22, 8, 0)) && semver.lt(new Semver(23, 6, 0))) {
+      this.capabilities |= Capability.ExperimentalTestIsolation;
+    }
+
+    // --test-isolation was added in v23.6.0
+    if (semver.gte(new Semver(23, 6, 0))) {
       this.capabilities |= Capability.TestIsolation;
     }
   }

--- a/src/runner-protocol.ts
+++ b/src/runner-protocol.ts
@@ -105,6 +105,8 @@ export const contract = makeContract({
             parameters: s.sArrayOf(s.sString()),
           }),
         ),
+        isolation: s.sString(),
+        forceExit: s.sBoolean(),
         extraEnv: s.sMap(s.sString()),
       }),
       result: s.sNull(),

--- a/src/runner-worker.ts
+++ b/src/runner-worker.ts
@@ -140,11 +140,19 @@ async function doWork(
       if (nodeVersion.has(Capability.TestForceExit) && forceExit) {
         args.push("--test-force-exit");
       }
-      if (nodeVersion.has(Capability.TestIsolation)) {
+      if (
+        nodeVersion.has(Capability.TestIsolation) ||
+        nodeVersion.has(Capability.ExperimentalTestIsolation)
+      ) {
         // Don't just splat any old value into the command line
         // whitelist them to prevent a shell injection attack
         if (isolation === "process" || isolation === "none") {
-          args.push(`--test-isolation=${isolation}`);
+          // Prefer using --test-isolation if that flag is supported
+          if (nodeVersion.has(Capability.TestIsolation)) {
+            args.push(`--test-isolation=${isolation}`);
+          } else {
+            args.push(`--experimental-test-isolation=${isolation}`);
+          }
         } else {
           console.warn(`Unknown isolation value: ${isolation}`);
         }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -48,6 +48,8 @@ export class TestRunner implements vscode.Disposable {
   private readonly disposables = new DisposableStore();
 
   private readonly concurrency: ConfigValue<number>;
+  private readonly isolation: ConfigValue<string>;
+  private readonly forceExit: ConfigValue<boolean>;
   private readonly nodejsPath: ConfigValue<string>;
   private readonly verbose: ConfigValue<boolean>;
   private readonly style: ConfigValue<Style>;
@@ -65,6 +67,9 @@ export class TestRunner implements vscode.Disposable {
   ) {
     this.workerPath = join(extensionDir, "out", "runner-worker.js");
     this.concurrency = this.disposables.add(new ConfigValue("concurrency", 0, folder));
+    this.isolation = this.disposables.add(new ConfigValue("isolation", "process", folder));
+    this.forceExit = this.disposables.add(new ConfigValue("forceExit", false, folder));
+
     this.nodejsPath = this.disposables.add(new ConfigValue("nodejsPath", "node", folder));
     this.verbose = this.disposables.add(new ConfigValue("verbose", false, folder));
     this.style = this.disposables.add(new ConfigValue("style", Style.Spec, folder));
@@ -131,6 +136,8 @@ export class TestRunner implements vscode.Disposable {
           ? join(tmpdir(), `nodejs-coverage-${randomUUID()}`)
           : undefined;
         const extensions = this.extensions.value;
+        const isolation = this.isolation.value;
+        const forceExit = this.forceExit.value;
         const envFile = this.envFile.value
           ? await fs.readFile(replaceVariables(this.envFile.value))
           : null;
@@ -298,6 +305,8 @@ export class TestRunner implements vscode.Disposable {
                 await reg.client.start({
                   files,
                   concurrency,
+                  isolation,
+                  forceExit,
                   extensions,
                   regenerateSnapshots: TestRunner.regenerateSnapshotsOnNextRun,
                   verbose: this.verbose.value,


### PR DESCRIPTION
Hey @connor4312, its me again.

My team utilizes these 2 options, so this is the last piece needed for us to use this extension.